### PR TITLE
added check to correct i2C reading

### DIFF
--- a/src/BARO.cpp
+++ b/src/BARO.cpp
@@ -57,8 +57,8 @@ float LPS22HBClass::readPressure(int units)
   // trigger one shot
   i2cWrite(LPS22HB_CTRL2_REG, 0x01);
 
-  // wait for completion
-  while ((i2cRead(LPS22HB_STATUS_REG) & 0x02) == 0) {
+  // wait for ONE_SHOT bit to be cleared by the hardware
+  while ((i2cRead(LPS22HB_CTRL2_REG) & 0x01) != 0) {
     yield();
   }
 


### PR DESCRIPTION
Added wait for ONE_SHOT bit to be cleared by the hardware for correct read of measurement

cc/: @sandeepmistry  this avoid an incorrect first measure read, would you counter check if can

to reproduce the issue:

1. Execute on nano 33 BLE the following sketch Example-<Arduino_LPS22HB->ReadPressure

2. Aftrer the upload the first readings returned is incorrect (Pressure = 75.93 kPa in my test when should be 99.02 kPa) 

3. adding this check all the measures are the same and the correct one
