### PR TITLE
Ensure readPressure function is executed only if begin returns 1

### DIFF
--- a/src/BARO.cpp
+++ b/src/BARO.cpp
@@ -31,7 +31,8 @@
 #define LPS22HB_PRESS_OUT_H_REG     0x2a
 
 LPS22HBClass::LPS22HBClass(TwoWire& wire) :
-  _wire(&wire)
+  _wire(&wire),
+  _initialized(false)
 {
 }
 
@@ -44,35 +45,40 @@ int LPS22HBClass::begin()
     return 0;
   }
 
+  _initialized = true;
   return 1;
 }
 
 void LPS22HBClass::end()
 {
   _wire->end();
+  _initialized = false;
 }
 
 float LPS22HBClass::readPressure(int units)
 {
-  // trigger one shot
-  i2cWrite(LPS22HB_CTRL2_REG, 0x01);
+  if (_initialized == true) {
+    // trigger one shot
+    i2cWrite(LPS22HB_CTRL2_REG, 0x01);
 
-  // wait for ONE_SHOT bit to be cleared by the hardware
-  while ((i2cRead(LPS22HB_CTRL2_REG) & 0x01) != 0) {
-    yield();
+    // wait for ONE_SHOT bit to be cleared by the hardware
+    while ((i2cRead(LPS22HB_CTRL2_REG) & 0x01) != 0) {
+      yield();
+    }
+
+    float reading = (i2cRead(LPS22HB_PRESS_OUT_XL_REG) |
+            (i2cRead(LPS22HB_PRESS_OUT_L_REG) << 8) |
+            (i2cRead(LPS22HB_PRESS_OUT_H_REG) << 16)) / 40960.0;
+
+    if (units == MILLIBAR) { // 1 kPa = 10 millibar
+      return reading * 10;
+    } else if (units == PSI) {  // 1 kPa = 0.145038 PSI
+      return reading * 0.145038;
+    } else {
+      return reading;
+    }
   }
-
-  float reading = (i2cRead(LPS22HB_PRESS_OUT_XL_REG) |
-          (i2cRead(LPS22HB_PRESS_OUT_L_REG) << 8) | 
-          (i2cRead(LPS22HB_PRESS_OUT_H_REG) << 16)) / 40960.0;
-
-  if (units == MILLIBAR) { // 1 kPa = 10 millibar
-    return reading * 10;
-  } else if (units == PSI) {  // 1 kPa = 0.145038 PSI
-    return reading * 0.145038;
-  } else {
-    return reading;
-  }
+  return 0;
 }
 
 int LPS22HBClass::i2cRead(uint8_t reg)

--- a/src/BARO.h
+++ b/src/BARO.h
@@ -44,6 +44,7 @@ private:
 
 private:
   TwoWire* _wire;
+  bool _initialized;
 };
 
 extern LPS22HBClass BARO;


### PR DESCRIPTION
With some example sketches  like https://opla.arduino.cc/opla/module/iot-starter-kit-maker/lesson/02-personal-weather-station the program execution goes on even if carrier.begin() returns an error. If the pressure sensor  (or any other sensor of the board) fails to initialize the following reading calls get stuck here 

https://github.com/arduino-libraries/Arduino_LPS22HB/blob/1f0a79382f49038aa7b45ee1c91526a74e3729a1/src/BARO.cpp#L61

because the sensor is not responding. On the MKR_WIFI_1010 this will lead to a watchdog infinite reset loop (watchdog is enabled by the IOT library).
Even if the board resets itself the sensor is never initialized correctly, the only thing i found working is to completely power off the board unplugging the usb connector, therefore, in this specific case, the watchdog resets are completely usless.
What i propose is to store the initialization return value and check it into the readPressure funcion avoiding any action if something went wrong during initialization phase and let the user decide when to reset/unplug the board.
If the changes are good i think we could extend them also to:
 - https://github.com/arduino-libraries/Arduino_HTS221
 - https://github.com/arduino-libraries/Arduino_LSM6DS3
 
and maybe some other library...