### PR TITLE
Added condition for if wire implementation lacks end()

### DIFF
--- a/src/BARO.cpp
+++ b/src/BARO.cpp
@@ -53,7 +53,9 @@ int LPS22HBClass::begin()
 
 void LPS22HBClass::end()
 {
+  #if defined(WIRE_HAS_END) && WIRE_HAS_END
   _wire->end();
+  #endif
   _initialized = false;
 }
 


### PR DESCRIPTION
Changed the end()  function so only if the platform implementation of TwoWire supports using the `TwoWire->end()` function, the `TwoWire->end()` function will be used. This was brought up since ESP32 framework doesn't have an end function to call. 

The Arduino docs do not specify an end function as a [official TwoWire API call](https://www.arduino.cc/en/Reference/Wire), rather if the implementation supports it a WIRE_HAS_END constant will be defined and set to 1.