### PR TITLE
support altitude in meters

### DIFF
--- a/examples/ReadPressure/ReadPressure.ino
+++ b/examples/ReadPressure/ReadPressure.ino
@@ -42,6 +42,16 @@ void loop() {
   // print an empty line
   Serial.println();
 
+  // read the sensor value
+  float altitude = BARO.readAltitude();
+  // print the sensor value
+  Serial.print("Altitude = ");
+  Serial.print(altitude);
+  Serial.println(" m");
+
+  // print an empty line
+  Serial.println();
+
   // wait 1 second to print again
   delay(1000);
 }

--- a/src/BARO.cpp
+++ b/src/BARO.cpp
@@ -93,6 +93,18 @@ float LPS22HBClass::readTemperature(void)
   return reading/100;
 }
 
+#define PRESSURE_SEALEVEL_HPA  (1013.25f) /**< Average sea level pressure is 1013.25 hPa */
+float LPS22HBClass::readAltitude(void)
+{
+  float atmospheric = BARO.readPressure(MILLIBAR);
+  /*
+   * The altitude in meters can be calculated
+   * with the international barometric formula
+   */
+  return 44330.0 *
+    (1.0 - pow(atmospheric/PRESSURE_SEALEVEL_HPA, (1.0/5.255)));
+}
+
 int LPS22HBClass::i2cRead(uint8_t reg)
 {
   _wire->beginTransmission(LPS22HB_ADDRESS);

--- a/src/BARO.h
+++ b/src/BARO.h
@@ -38,7 +38,7 @@ public:
 
   float readPressure(int units = KILOPASCAL);
   float readTemperature(void);
-
+  float readAltitude(void);
 private:
   int i2cRead(uint8_t reg);
   int i2cWrite(uint8_t reg, uint8_t val);


### PR DESCRIPTION
Support the altitude reporting in meters via the Barometric equation and the [International Standard Atmosphere](http://fisicaatmo.at.fcen.uba.ar/practicas/ISAweb.pdf) model.
