### PR TITLE
Correct enumerator name for kilopascal units in docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -84,7 +84,7 @@ BARO.readPressure(units)
 
 #### Parameters
 
-* _units_: `PSI`  to read the pressure in PSI (pounds per square inch), `MILLIBAR` to read the pressure in millibars and `KILOPASCALS` to read the pressure in kilopascals. If unit parameter is not provided, default is kilopascals   .
+* _units_: `PSI`  to read the pressure in PSI (pounds per square inch), `MILLIBAR` to read the pressure in millibars and `KILOPASCAL` to read the pressure in kilopascals. If unit parameter is not provided, default is kilopascals   .
 
 #### Returns
 


### PR DESCRIPTION
The library declares an enum of the unit types supported for configuration of the return value of the `readPressure` function:

https://github.com/arduino-libraries/Arduino_LPS22HB/blob/779bf6a26d5c6c67ba247bb02121e8a1e657394b/src/BARO.h#L26-L30

The names of the enumerators are documented in the API docs.

Previously, the name of the enumerator for kilopascal units was misspelled in the documentation.

---

Originally reported at https://forum.arduino.cc/t/arduino-lpss22hb-unit-parameter-error-kilopascals-vs-kilopascal/1253691